### PR TITLE
Removed error event being dispatched in abort

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+Forked from original sse.js repo. Removed the 'error' event being dispatched
+on abort. My opinion is 'abort' is more like a user action than an error.
+
 # sse.js
 
 `sse.js` is a flexible `EventSource` replacement for JavaScript designed

--- a/lib/sse.js
+++ b/lib/sse.js
@@ -184,7 +184,6 @@ var SSE = function (url, options) {
     this.xhr.addEventListener('load', this._onStreamLoaded.bind(this));
     this.xhr.addEventListener('readystatechange', this._checkStreamClosed.bind(this));
     this.xhr.addEventListener('error', this._onStreamFailure.bind(this));
-    this.xhr.addEventListener('abort', this._onStreamFailure.bind(this));
     this.xhr.open(this.method, this.url);
     for (var header in this.headers) {
       this.xhr.setRequestHeader(header, this.headers[header]);

--- a/lib/sse.js
+++ b/lib/sse.js
@@ -94,6 +94,11 @@ var SSE = function (url, options) {
     this.close();
   }
 
+  this._onStreamAbort = function(e) {
+    this.dispatchEvent(new CustomEvent('abort'));
+    this.close();
+  }
+
   this._onStreamProgress = function(e) {
     if (!this.xhr) {
       return;
@@ -184,6 +189,7 @@ var SSE = function (url, options) {
     this.xhr.addEventListener('load', this._onStreamLoaded.bind(this));
     this.xhr.addEventListener('readystatechange', this._checkStreamClosed.bind(this));
     this.xhr.addEventListener('error', this._onStreamFailure.bind(this));
+    this.xhr.addEventListener('abort', this._onStreamAbort.bind(this));
     this.xhr.open(this.method, this.url);
     for (var header in this.headers) {
       this.xhr.setRequestHeader(header, this.headers[header]);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sse.js",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "A flexible Server-Sent Events source; supports POST requests and custom headers",
   "main": "./lib/sse.js",
   "scripts": {


### PR DESCRIPTION
Removed the 'error' event being dispatched on abort. My opinion is 'abort' is more like a user action than an error.