### PR TITLE
Changes to add error message from error response

### DIFF
--- a/lib/sse.js
+++ b/lib/sse.js
@@ -90,7 +90,9 @@ var SSE = function (url, options) {
   };
 
   this._onStreamFailure = function(e) {
-    this.dispatchEvent(new CustomEvent('error'));
+    var event = new CustomEvent('error');
+    event.data = e.response;
+    this.dispatchEvent(event);
     this.close();
   }
 

--- a/lib/sse.js
+++ b/lib/sse.js
@@ -91,7 +91,7 @@ var SSE = function (url, options) {
 
   this._onStreamFailure = function(e) {
     var event = new CustomEvent('error');
-    event.data = e.response;
+    event.data = e.currentTarget.response;
     this.dispatchEvent(event);
     this.close();
   }


### PR DESCRIPTION
If an error happens in the initial connection & the api renders a response message with it, then that error message isn't available to show with the error CustomEvent. This PR adds the same.