### PR TITLE
fix: early matching and splitting events incorrectly

### DIFF
--- a/lib/sse.js
+++ b/lib/sse.js
@@ -118,7 +118,7 @@ var SSE = function (url, options) {
 
     var data = this.xhr.responseText.substring(this.progress);
     this.progress += data.length;
-    data.split(/(\r\n|\r|\n){2}/g).forEach(function(part) {
+    data.split(/(\r\n|\n){2}/g).forEach(function(part) {
       if (part.trim().length === 0) {
         this.dispatchEvent(this._parseEventChunk(this.chunk.trim()));
         this.chunk = '';


### PR DESCRIPTION
Otherwise this is true
```
var regex = /(\r\n|\r|\n){2}/g;
regex.test("\r\n\r");
```