### PR TITLE
Better event stream parsing

### DIFF
--- a/lib/sse.js
+++ b/lib/sse.js
@@ -145,6 +145,7 @@ var SSE = function (url, options) {
     }
 
     var e = {'id': null, 'retry': null, 'data': '', 'event': 'message'};
+    var hasNewLine = false;
     chunk.split(/\n|\r\n|\r/).forEach(function(line) {
       line = line.trimRight();
       var index = line.indexOf(this.FIELD_SEPARATOR);
@@ -159,9 +160,17 @@ var SSE = function (url, options) {
         return;
       }
 
-      var value = line.substring(index + 1).trimLeft();
+      var value = line.substring(index + 1);
+      if (value.charAt(0) === ' ') {
+        value = value.substring(1);
+      }
+      
       if (field === 'data') {
-        e[field] += value;
+        if (hasNewLine) {
+          e.data += '\n';
+        }
+        e.data += value;
+        hasNewLine = true;
       } else {
         e[field] = value;
       }

--- a/lib/sse.js
+++ b/lib/sse.js
@@ -149,10 +149,14 @@ var SSE = function (url, options) {
     chunk.split(/\n|\r\n|\r/).forEach(function(line) {
       line = line.trimRight();
       var index = line.indexOf(this.FIELD_SEPARATOR);
-      if (index <= 0) {
-        // Line was either empty, or started with a separator and is a comment.
-        // Either way, ignore.
+      if (index === 0) {
+        // Line started with a separator and is a comment, ignore.
         return;
+      }
+
+      if (index < 0) {
+        // Line was empty, use whole line as the field name and the empty string as value.
+        index = line.length;
       }
 
       var field = line.substring(0, index);


### PR DESCRIPTION
Interpretation changes according to [SSE Spec](https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation):

- Lines which are not empty but do not contain a colon character are interpreted as a field with empty field value. Eg:
  ```
  data
  ```
  will fire an event with `data: ""`.
- At most one space is allowed after the colon seperator. More spaces are interpreted as part of field values. Eg:
  ```
  data:  foo
  ```
  will fire an event with `data: " foo"` rather than `data: "foo"`.
- Consecutive `data` fields are separated by line breaks. This is useful for multiline data. Eg:
  ```
  data: foo
  data: bar
  ```
  will fire an event with `data: "foo\nbar"` rather than `data: "foobar"`.

These edge cases may be used for transferring pre-formatted contents like Markdown and other space-sensitive markups :)