### PR TITLE
fix: mark SSEOptions properties as optional

### DIFF
--- a/lib/sse.js
+++ b/lib/sse.js
@@ -290,11 +290,11 @@ export { SSE };
  */
 /**
  * @typedef {Object} SSEOptions
- * @property {SSEHeaders} headers - headers
- * @property {string} payload - payload as a string
- * @property {string} method - HTTP Method
- * @property {boolean} withCredentials - flag, if credentials needed
- * @property {boolean} debug - debugging flag
+ * @property {SSEHeaders} [headers] - headers
+ * @property {string} [payload] - payload as a string
+ * @property {string} [method] - HTTP Method
+ * @property {boolean} [withCredentials] - flag, if credentials needed
+ * @property {boolean} [debug] - debugging flag
  */
 /**
  * @typedef {Object} _SSEvent

--- a/types/sse.d.ts
+++ b/types/sse.d.ts
@@ -45,23 +45,23 @@ export type SSEOptions = {
     /**
      * - headers
      */
-    headers: SSEHeader;
+    headers?: SSEHeader;
     /**
      * - payload as a string
      */
-    payload: string;
+    payload?: string;
     /**
      * - HTTP Method
      */
-    method: string;
+    method?: string;
     /**
      * - flag, if credentials needed
      */
-    withCredentials: boolean;
+    withCredentials?: boolean;
     /**
      * - debugging flag
      */
-    debug: boolean;
+    debug?: boolean;
 };
 export type _SSEvent = {
     id: string;


### PR DESCRIPTION
The `SSEOptions` seem to be optional according to the README.