### PR TITLE
Update property header from SSE from string to SSEHeaders

### DIFF
--- a/lib/sse.js
+++ b/lib/sse.js
@@ -369,7 +369,7 @@ export { SSE };
  */
 /**
  * @typedef {Object} SSE
- * @property {string} headers - headers
+ * @property {SSEHeaders} headers - headers
  * @property {string} payload - payload as a string
  * @property {string} method - HTTP Method
  * @property {boolean} withCredentials - flag, if credentials needed

--- a/types/sse.d.ts
+++ b/types/sse.d.ts
@@ -45,7 +45,7 @@ export type SSEOptions = {
     /**
      * - headers
      */
-    headers?: SSEHeader;
+    headers?: SSEHeaders;
     /**
      * - payload as a string
      */


### PR DESCRIPTION
This pull request updates the `headers` property in `SSE` from `string` to `SSEHeaders` type. Additionally, it fixes the `SSEHeaders` type name for `SSEOptions`.

This change ensures that the `headers` property is used consistently throughout the codebase and avoids any potential type errors.