### PR TITLE
Fix spec deviations

### DIFF
--- a/lib/sse.js
+++ b/lib/sse.js
@@ -189,7 +189,6 @@ var SSE = function (url, options) {
 
     var e = {'id': null, 'retry': null, 'data': null, 'event': 'message'};
     chunk.split(/\n|\r\n|\r/).forEach(function(line) {
-      line = line.trimRight();
       var index = line.indexOf(this.FIELD_SEPARATOR);
       if (index <= 0) {
         // Line was either empty, or started with a separator and is a comment.

--- a/lib/sse.js
+++ b/lib/sse.js
@@ -187,7 +187,7 @@ var SSE = function (url, options) {
       console.debug(chunk);
     }
 
-    var e = {'id': null, 'retry': null, 'data': null, 'event': 'message'};
+    var e = {'id': null, 'retry': null, 'data': null, 'event': null};
     chunk.split(/\n|\r\n|\r/).forEach(function(line) {
       var index = line.indexOf(this.FIELD_SEPARATOR);
       var field, value;
@@ -217,7 +217,7 @@ var SSE = function (url, options) {
       }
     }.bind(this));
 
-    var event = new CustomEvent(e.event);
+    var event = new CustomEvent(e.event || 'message');
     event.data = e.data || '';
     event.id = e.id;
     return event;

--- a/lib/sse.js
+++ b/lib/sse.js
@@ -190,20 +190,24 @@ var SSE = function (url, options) {
     var e = {'id': null, 'retry': null, 'data': null, 'event': 'message'};
     chunk.split(/\n|\r\n|\r/).forEach(function(line) {
       var index = line.indexOf(this.FIELD_SEPARATOR);
-      if (index <= 0) {
-        // Line was either empty, or started with a separator and is a comment.
-        // Either way, ignore.
+      var field, value;
+      if (index > 0) {
+        // only first whitespace should be trimmed
+        var skip = (line[index+1] === ' ') ? 2 : 1;
+        field = line.substring(0, index);
+        value = line.substring(index + skip);
+      } else if (index < 0) {
+        // Interpret the entire line as the field name, and use the empty string as the field value
+        field = line;
+        value = '';
+      } else {
+        // A colon is the first character. This is a comment; ignore it.
         return;
       }
 
-      var field = line.substring(0, index);
       if (!(field in e)) {
         return;
       }
-
-      // only first whitespace should be trimmed
-      var skip = (line[index+1] === ' ') ? 2 : 1;
-      var value = line.substring(index + skip);
 
       // consecutive 'data' is concatenated with newlines
       if (field === 'data' && e[field] !== null) {

--- a/lib/sse.test.js
+++ b/lib/sse.test.js
@@ -216,6 +216,27 @@ describe('SSE Event handling and Listeners', () => {
     expect(customListener.mock.calls[0][0].type).toBe('customEvent');
   });
 
+  it('should preserve trailing whitespace', () => {
+    sse.xhr.responseText = 'data: whitespace      \n\ndata: whitespace 2     \r\rdata: whitespace 3     \r\n\r\ndata: no whitespace\n\n';
+    sse.xhr.trigger('progress', {});
+    expect(listener).toHaveBeenCalledTimes(4);
+    expect(listener.mock.calls[0][0].data).toBe('whitespace      ');
+    expect(listener.mock.calls[1][0].data).toBe('whitespace 2     ');
+    expect(listener.mock.calls[2][0].data).toBe('whitespace 3     ');
+    expect(listener.mock.calls[3][0].data).toBe('no whitespace');
+  });
+
+  it('should handle lines without a field separator', () => {
+    sse.xhr.responseText = 'data: foo\ndata\ndata\ndata: bar\n\ndata: baz\nevent\nid: overwriteme\nid\n\n';
+    sse.xhr.trigger('progress', {});
+    expect(listener).toHaveBeenCalledTimes(2);
+    expect(listener.mock.calls[0][0].data).toBe('foo\n\n\nbar');
+
+    expect(listener.mock.calls[1][0].data).toBe('baz');
+    expect(listener.mock.calls[1][0].event).toBe(undefined);
+    expect(listener.mock.calls[1][0].id).toBe('');
+  });
+
   it('should remove listeners successfully', () => {
     sse.removeEventListener('message', listener);
     sse.xhr.responseText = 'data: Test message\n\n';

--- a/lib/sse.test.js
+++ b/lib/sse.test.js
@@ -237,6 +237,14 @@ describe('SSE Event handling and Listeners', () => {
     expect(listener.mock.calls[1][0].id).toBe('');
   });
 
+  it('should treat a blank event type as \'message\'', () => {
+    sse.xhr.responseText = 'data: foo\nevent: overwriteme\ndata: bar\nevent:\n\n';
+    sse.xhr.trigger('progress', {});
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener.mock.calls[0][0].data).toBe('foo\nbar');
+    expect(listener.mock.calls[0][0].event).toBe(undefined);
+  });
+
   it('should remove listeners successfully', () => {
     sse.removeEventListener('message', listener);
     sse.xhr.responseText = 'data: Test message\n\n';


### PR DESCRIPTION
Resolves #48.

I've modified the parser to stop trimming trailing whitespace, to treat lines without colons as fields with blank values, and to default the event type to "message" at construction time. These all match the spec's prescribed behaviors. I've also added tests for these scenarios to ensure it does the correct things.