### PR TITLE
Update `payload` types to support all XMLHttpRequest types

### DIFF
--- a/types/sse.d.ts
+++ b/types/sse.d.ts
@@ -1,84 +1,84 @@
 export type SSE = {
-    /** Constructor. */
-    new (url: string, options?: SSEOptions): SSE;
+  /** Constructor. */
+  new (url: string, options?: SSEOptions): SSE;
 
-    /**
-     * - headers
-     */
-    headers: SSEHeaders;
-    /**
-     * - payload as a string
-     */
-    payload: string;
-    /**
-     * - HTTP Method
-     */
-    method: string;
-    /**
-     * - flag, if credentials needed
-     */
-    withCredentials: boolean;
-    /**
-     * - debugging flag
-     */
-    debug: boolean;
-    FIELD_SEPARATOR: string;
-    listeners: Record<string, Function[]>;
-    xhr: XMLHttpRequest | null;
-    readyState: number;
-    progress: number;
-    chunk: string;
-    INITIALIZING: -1;
-    CONNECTING: 0;
-    OPEN: 1;
-    CLOSED: 2;
-    addEventListener: AddEventListener;
-    removeEventListener: RemoveEventListener;
-    dispatchEvent: DispatchEvent;
-    stream: Stream;
-    close: Close;
-    onmessage: OnMessage;
-    onopen: OnOpen;
-    onload: OnLoad;
-    onreadystatechange: OnReadystatechange;
-    onerror: OnError;
-    onabort: OnAbort;
+  /**
+   * - headers
+   */
+  headers: SSEHeaders;
+  /**
+   * - payload as a Blob, ArrayBuffer, Dataview, FormData, URLSearchParams, or string
+   */
+  payload?: Blob | ArrayBuffer | DataView | FormData | URLSearchParams | string;
+  /**
+   * - HTTP Method
+   */
+  method: string;
+  /**
+   * - flag, if credentials needed
+   */
+  withCredentials: boolean;
+  /**
+   * - debugging flag
+   */
+  debug: boolean;
+  FIELD_SEPARATOR: string;
+  listeners: Record<string, Function[]>;
+  xhr: XMLHttpRequest | null;
+  readyState: number;
+  progress: number;
+  chunk: string;
+  INITIALIZING: -1;
+  CONNECTING: 0;
+  OPEN: 1;
+  CLOSED: 2;
+  addEventListener: AddEventListener;
+  removeEventListener: RemoveEventListener;
+  dispatchEvent: DispatchEvent;
+  stream: Stream;
+  close: Close;
+  onmessage: OnMessage;
+  onopen: OnOpen;
+  onload: OnLoad;
+  onreadystatechange: OnReadystatechange;
+  onerror: OnError;
+  onabort: OnAbort;
 };
 export type SSEHeaders = {
-    [key: string]: string;
+  [key: string]: string;
 };
 export type SSEOptions = {
-    /**
-     * - headers
-     */
-    headers?: SSEHeaders;
-    /**
-     * - payload as a string
-     */
-    payload?: string;
-    /**
-     * - HTTP Method
-     */
-    method?: string;
-    /**
-     * - flag, if credentials needed
-     */
-    withCredentials?: boolean;
-    /**
-     * - flag, if streaming should start automatically
-     */
-    start?: boolean;
-    /**
-     * - debugging flag
-     */
-    debug?: boolean;
+  /**
+   * - headers
+   */
+  headers?: SSEHeaders;
+  /**
+   * - payload as a Blob, ArrayBuffer, Dataview, FormData, URLSearchParams, or string
+   */
+  payload?: Blob | ArrayBuffer | DataView | FormData | URLSearchParams | string;
+  /**
+   * - HTTP Method
+   */
+  method?: string;
+  /**
+   * - flag, if credentials needed
+   */
+  withCredentials?: boolean;
+  /**
+   * - flag, if streaming should start automatically
+   */
+  start?: boolean;
+  /**
+   * - debugging flag
+   */
+  debug?: boolean;
 };
 export type _SSEvent = {
-    id: string;
-    data: string;
+  id: string;
+  data: string;
 };
 export type _ReadyStateEvent = {
-    readyState: number;
+  readyState: number;
 };
 export type SSEvent = Event & _SSEvent;
 export type ReadyStateEvent = SSEvent & _ReadyStateEvent;


### PR DESCRIPTION
**[As per the XMLHttpRequest `send()` method's API](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/send)**

The `body` parameter in the `send(body)` method allows for multiple types, such as (but not limited to) Blobs, ArrayBuffers, and FormData. The implementation in sse.js only allows for strings to be sent in the POST request, which is fairly limiting.

This change should allow for all* types supported by the XMLHttpRequest to be supported via sse.js.

*Omitting TypedArray, as that has 11 different types associated with it, and I wasn't sure if it was that necessary. This could absolutely be adjusted to support them, however.