### PR TITLE
fix: Added data parsing '\n\r\n' ending rule

### DIFF
--- a/lib/sse.js
+++ b/lib/sse.js
@@ -164,7 +164,7 @@ var SSE = function (url, options) {
     const data = this.xhr.responseText.substring(this.progress);
     this.progress += data.length;
 
-    const parts = (this.chunk + data).split(/(\r\n\r\n|\r\r|\n\n)/g);
+    const parts = (this.chunk + data).split(/(\r\n\r\n|\r\r|\n\n|\n\r\n)/g);
 
     /*
      * We assume that the last chunk can be incomplete because of buffering or other network effects,


### PR DESCRIPTION
The "\n\r\n" ending data will not be parsed correctly, and the message event will not be called correctly.
![image](https://github.com/user-attachments/assets/3589f595-4a94-4976-85d6-aa43f4b378e8)
