### PR TITLE
fix: clear the internal state on close

### DIFF
--- a/lib/sse.js
+++ b/lib/sse.js
@@ -126,6 +126,8 @@ var SSE = function (url, options) {
   /** @private */
   this._markClosed = function() {
     this.xhr = null;
+    this.progress = 0;
+    this.chunk = '';
     this._setReadyState(SSE.CLOSED);
   };
 


### PR DESCRIPTION
This code causes a loss of events due to a stale internal state:

```js
const sse = new EventSource('...');

setTimeout(() => {
  sse.close();
  sse.stream();
}, 5000);
```

It's because here we use progress and chunk and they are not cleaned on close.
https://github.com/mpetazzoni/sse.js/blob/ee7d4cd0b5798c944ca0b2723c7250a5c5e6c65a/lib/sse.js#L164-L167
