### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,7 +338,7 @@ respectivitely:
 var source = new SSE(url);
 source.addEventListener("open", function (e) {
   console.log(
-    "Got a " + e.data.responseCode + " response with headers: " + e.data.headers
+    "Got a " + e.responseCode + " response with headers: " + e.headers
   );
 });
 source.stream();


### PR DESCRIPTION
The `open` event example incorrectly accesses `responseCode` and `headers` via `e.data`, but these properties are available directly on the event object.