### PR TITLE
fix: close called during infinite retry

### DIFF
--- a/lib/sse.js
+++ b/lib/sse.js
@@ -378,10 +378,6 @@ var SSE = function (url, options) {
    * @return {void}
    */
   this.close = function () {
-    if (this.readyState === SSE.CLOSED) {
-      return;
-    }
-
     // Clear any pending reconnect timer and disable auto-reconnect
     if (this.reconnectTimer) {
       clearTimeout(this.reconnectTimer);
@@ -390,7 +386,9 @@ var SSE = function (url, options) {
     // Disable auto-reconnect when explicitly closed
     this.autoReconnect = false;
 
-    this.xhr.abort();
+    if (this.xhr) {
+      this.xhr.abort();
+    }
   };
 
   if (options.start === undefined || options.start) {


### PR DESCRIPTION
Fixes: https://github.com/mpetazzoni/sse.js/issues/95

When using autoReconnect with infinite retries, calling `close` does not stop the retries.
 