### PR TITLE
fix: refine SSEPayload type

### DIFF
--- a/lib/sse.js
+++ b/lib/sse.js
@@ -419,12 +419,12 @@ export { SSE };
  * @typedef { {[key: string]: string} } SSEHeaders
  */
 /**
- * @typedef {Document | Blob | ArrayBuffer | TypedArray | DataView | FormData | URLSearchParams | string | null} SSEPayload
+ * @typedef {Blob | ArrayBuffer | DataView | FormData | URLSearchParams | string | null} SSEPayload
  */
 /**
  * @typedef {Object} SSEOptions
  * @property {SSEHeaders} [headers] - headers
- * @property {SSEPayload} [payload] - payload as a string
+ * @property {SSEPayload} [payload] - payload
  * @property {string} [method] - HTTP Method
  * @property {boolean} [withCredentials] - flag, if credentials needed
  * @property {boolean} [start] - flag, if streaming should start automatically
@@ -512,7 +512,7 @@ export { SSE };
 /**
  * @typedef {Object} SSE
  * @property {SSEHeaders} headers - headers
- * @property {SSEPayload} payload - payload as a string
+ * @property {SSEPayload} payload - payload
  * @property {string} method - HTTP Method
  * @property {boolean} withCredentials - flag, if credentials needed
  * @property {boolean} debug - debugging flag

--- a/types/sse.d.ts
+++ b/types/sse.d.ts
@@ -68,7 +68,7 @@ export type SSE = {
 export type SSEHeaders = {
   [key: string]: string;
 };
-export type SSEPayload = Document | Blob | ArrayBuffer | TypedArray | DataView | FormData | URLSearchParams | string | null;
+export type SSEPayload = Blob | ArrayBuffer | DataView | FormData | URLSearchParams | string | null;
 export type SSEOptions = {
   /**
    * - headers


### PR DESCRIPTION
Some types added in the JSDoc in the commit https://github.com/mpetazzoni/sse.js/commit/f0c3b17eb8549a0f33ef7dfd44a31a2782536671 and in the .d.ts in #94 are not correct.

Document points to the DOM ([ref](https://developer.mozilla.org/en-US/docs/Web/API/Document)).

TypedArray is a valid JS object but an invalid Typescript type by default, there is no supertype, but one type for each sub types instead. ([ref](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray)) ([playground](https://www.typescriptlang.org/play/?target=99&module=200&inlineSourceMap=false#code/DYUwLgBAhhBcEBUCeAHEATAggJ21JA3AFCiQBG8AkgHZgAcOehQA))