### PR TITLE
fix: correct DispatchEvent type signature to match EventTarget API

### DIFF
--- a/lib/sse.js
+++ b/lib/sse.js
@@ -477,8 +477,7 @@ export { SSE };
  */
 /**
  * @callback DispatchEvent
- * @param {string} type
- * @param {function} listener
+ * @param {CustomEvent | null} e
  * @returns {boolean}
  */
 /**

--- a/types/sse.d.ts
+++ b/types/sse.d.ts
@@ -126,7 +126,7 @@ export type SSEvent = Event & _SSEvent;
 export type ReadyStateEvent = SSEvent & _ReadyStateEvent;
 export type AddEventListener = (type: string, listener: Function) => void;
 export type RemoveEventListener = (type: string, listener: Function) => void;
-export type DispatchEvent = (type: string, listener: Function) => boolean;
+export type DispatchEvent = (e: CustomEvent | null) => boolean;
 export type Stream = () => void;
 export type Close = () => void;
 export type OnMessage = (event: SSEvent) => void;


### PR DESCRIPTION
## Summary
The previous type definition didn't match the actual EventTarget.dispatchEvent() method. This ensures type safety and consistency with browser standards.

## Changes
- Updated `DispatchEvent` callback JSDoc in `lib/sse.js` to accept a `CustomEvent | null` parameter instead of separate `type` and `listener` parameters
- Updated TypeScript type definition in `types/sse.d.ts` to match the corrected signature